### PR TITLE
fix fastdl sync script

### DIFF
--- a/TF2SyncToFastDL.bat
+++ b/TF2SyncToFastDL.bat
@@ -1,0 +1,6 @@
+powershell.exe -executionpolicy bypass -file "TF2SyncToFastDL.ps1"
+
+REM -windowstyle hidden -noninteractive -nologo
+
+REM comment this out before putting this into production
+REM pause

--- a/TF2SyncToFastDL.ps1
+++ b/TF2SyncToFastDL.ps1
@@ -1,26 +1,27 @@
+###
 ### Sync map directory to fastdl server
 ###
-### This script assumes that 
+
 
 ### Configuration
-$FastDLServer = "sftp://fithnet:CHANGETHISPASSWORD@hosted.nfoservers.com/"
+$FastDLServer = "sftp://USERNAME:PASSWORD@hosted.nfoservers.com/"
 $RemoteMapTarget = "/usr/www/fithnet/public/FastDL/maps/"
 $MapPath = "C:\Games\tf2maps"
 $TransferStagingPath = Join-Path $ENV:Temp "tf2maps"
 
 # Check WinSCP path
 if([Environment]::Is64BitOperatingSystem) {
-    $WinSCPPath = Join-Path ${env:programfiles(x86)} "WinSCP" "WinSCP.com"
+    $WinSCPPath = Join-Path ${env:programfiles(x86)} (Join-Path "WinSCP" "WinSCP.com")
 }
 else {
-    $WinSCPPath = Join-Path $env:programfiles "WinSCP" "WinSCP.com"
+    $WinSCPPath = Join-Path $env:programfiles (Join-Path "WinSCP" "WinSCP.com")
 }
 if(-not (Test-Path $WinSCPPath)){
     Write-Error "$WinSCPPath is needed!" -RecommendedAction "Install WinSCP" -ErrorAction:Stop
 }
 
 # Check 7zip path
-$7zPath = Join-Path $env:programfiles "7-zip" "7z.exe"
+$7zPath = Join-Path $env:programfiles (Join-Path "7-zip" "7z.exe")
 if (-not (Test-Path $7zPath)){
     Write-Error "$7zPath needed!" -RecommendedAction "Install 7zip" -ErrorAction:Stop
 }
@@ -31,7 +32,11 @@ New-Item -ItemType Directory -Force -Path $TransferStagingPath
 #Create BZ2 archives for each BSP file in folder
 $BSPFiles = @(Get-ChildItem (Join-Path $MapPath "*.bsp"))
 foreach ($BSPfile in $BSPFiles) {
-    & $7zPath "a" "-tbzip2" (Join-Path $TransferStagingPath "$($BSPFile.name).bz2") (Join-Path $MapPath $BSPFile.name)
+	$SourcePath = Join-Path $MapPath $BSPFile.name
+	$DestPath = Join-Path $TransferStagingPath "$($BSPFile.name).bz2"
+	if (-not (Test-Path -Path $DestPath -PathType Leaf)) {
+		(& $7zPath "a" "-mmt1" "-tbzip2" $DestPath $SourcePath)
+	}
 }
 
 # Open SFTP Session to Webserver
@@ -41,5 +46,5 @@ foreach ($BSPfile in $BSPFiles) {
 /log="$(Join-Path $TransferStagingPath "FITHNET.log")" `
 /command `
 "open $FastDLServer" `
-"synchronize remote -criteria=checksum -filemask=`"*.bz2`" $TransferStagingPath $RemoteMapTarget" `
+"synchronize remote -preview -criteria=checksum -filemask=`"*.bz2`" $TransferStagingPath $RemoteMapTarget" `
 "exit"

--- a/TF2SyncToFastDL.ps1
+++ b/TF2SyncToFastDL.ps1
@@ -5,7 +5,7 @@
 
 ### Configuration
 $FastDLServer = "sftp://USERNAME:PASSWORD@hosted.nfoservers.com/"
-$FastDLServerHostKey = "HirHG9VT3uH/YaMNZIZq1iH+u1AqeJdV6t0qIV3JO7E"
+$FastDLServerHostKey = "Put key fingerprint for server here"
 $RemoteMapTarget = "/usr/www/fithnet/public/FastDL/maps/"
 $MapPath = "C:\Games\tf2maps"
 $TransferStagingPath = Join-Path $ENV:Temp "tf2maps"

--- a/TF2SyncToFastDL.ps1
+++ b/TF2SyncToFastDL.ps1
@@ -5,6 +5,7 @@
 
 ### Configuration
 $FastDLServer = "sftp://USERNAME:PASSWORD@hosted.nfoservers.com/"
+$FastDLServerHostKey = "HirHG9VT3uH/YaMNZIZq1iH+u1AqeJdV6t0qIV3JO7E"
 $RemoteMapTarget = "/usr/www/fithnet/public/FastDL/maps/"
 $MapPath = "C:\Games\tf2maps"
 $TransferStagingPath = Join-Path $ENV:Temp "tf2maps"
@@ -43,8 +44,8 @@ foreach ($BSPfile in $BSPFiles) {
 # change to target directory
 # copy BZ2 archives
 & $WinSCPPath `
-/log="$(Join-Path $TransferStagingPath "FITHNET.log")" `
+/log="$(Join-Path $TransferStagingPath "zzz_FITHNET.log")" `
 /command `
-"open $FastDLServer" `
-"synchronize remote -preview -criteria=checksum -filemask=`"*.bz2`" $TransferStagingPath $RemoteMapTarget" `
+"open $FastDLServer -hostkey=`"$FastDLServerHostKey`"" `
+"synchronize remote -criteria=checksum -filemask=`"*.bz2`" $TransferStagingPath $RemoteMapTarget" `
 "exit"


### PR DESCRIPTION
hadn't had a chance to test this yet, after testing there were a few things that needed adjusted.

- added a batch file to deal with powershell execution policy
- added host key bits to make winscp happy
- fixed some `Join-Path` syntax assumptions that don't hold up for older versions of powershell
- added code to skip compressing files if they already exist
- renamed log file so it is always at the bottom of the temp directory and easier to find